### PR TITLE
Upgrading actions/upload-artifact@v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,12 @@ jobs:
           yarn run lint
           yarn run test
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: coverage/lcov-report/*
           retention-days: 5
+          overwrite: true
       # Just in case someone commits a change without running 'yarn run build'
       - uses: EndBug/add-and-commit@v9
         with:


### PR DESCRIPTION
# High Bar Approval

## 1. JIRA:
[Replace v3 actions/upload-artifact and actions/download-artifact](https://lcvista.atlassian.net/browse/DEVOPS-132)

## 2. What is changing for customers?
No change for customers.

## 3. Why is this change important to release to customers now?
If not addressed promptly, this has the potential to disrupt our ability to build and deploy our code.

## 4. What would be the effect on customers of waiting to release?
If not addressed promptly, this has the potential to disrupt our ability to build and deploy our code.

## 5. What part of code is being changed?
Build infrastructure.

## 6. How was this tested?  Include any evidence.
Tested using the Prolaera migration [build process](https://github.com/LCVista/prolaera_migration/actions/runs/12377524178/job/34547230659).